### PR TITLE
Fixed edit term_category on Rails4

### DIFF
--- a/app/controllers/term_categories_controller.rb
+++ b/app/controllers/term_categories_controller.rb
@@ -19,7 +19,7 @@ class TermCategoriesController < ApplicationController
   
   def edit
     @category = TermCategory.find_by(project_id: @project.id,  id: params[:id])
-    if request.put? and @category.update_attributes(params[:category])
+    if request.patch? and @category.update_attributes(params[:category])
       flash[:notice] = l(:notice_successful_update)
       redirect_to :controller => 'term_categories', :action => 'index', :project_id => @project
     end


### PR DESCRIPTION
Cannot edit term_category on Rails4.
Cause of request is patch instead of put.