### PR TITLE
fix mysql migration error

### DIFF
--- a/db/migrate/004_rename_glossary_terms_from_terms.rb
+++ b/db/migrate/004_rename_glossary_terms_from_terms.rb
@@ -3,7 +3,9 @@ class RenameGlossaryTermsFromTerms < ActiveRecord::Migration[5.2]
     remove_column :terms, :tech_en, :string
     remove_column :terms, :name_cn, :string
     remove_column :terms, :name_fr, :string
+    change_column :terms, :created_on, :timestamp, default: -> { 'CURRENT_TIMESTAMP' }
     rename_column :terms, :created_on, :created_at
+    change_column :terms, :updated_on, :timestamp, default: -> { 'CURRENT_TIMESTAMP' }
     rename_column :terms, :updated_on, :updated_at
     rename_table :terms, :glossary_terms
   end


### PR DESCRIPTION
### 発生している事象

マイグレーションを実行するとエラーが発生し、インストールに失敗する。

エラーの内容を確認したところ、マイグレーション実行時に以下のSQLが事項されており、
そこでSQLエラーが発生しマイグレーションが失敗していた。

```
ALTER TABLE `terms` CHANGE `created_on` `created_at` timestamp DEFAULT NULL
```

上記SQLおよびSQLエラーの原因を調べたところ、以下にURLに記載された内容と同じ原因だと思われる。

[Railsのバグでは？マイグレーションでMySQLのTIMESTAMP型にNULL 値を許可すると異常系がある](https://tech.actindi.net/2019/12/06/090000)

### 修正を行った内容

参考URLの通りであれば、プラグイン側の問題では無くRails自体の問題となりますが、
現実問題として、マイグレーションに失敗してしまうため、
エラーが発生しているマイグレーションファイルのカラム名変更処理実行前に
対象カラムの初期値をCURRENT_TIMESTAMPに設定することで、上記SQLが発行されることを回避しています。

もし問題が無いようでしたらマージしていただけるとありがたく思います